### PR TITLE
Use custom valid file upload extensions

### DIFF
--- a/civiremote_funding.services.yml
+++ b/civiremote_funding.services.yml
@@ -10,6 +10,11 @@ services:
     parent: logger.channel_base
     arguments: [ 'civiremote_funding' ]
 
+  civiremote_funding.settings:
+    class: Drupal\Core\Config\ImmutableConfig
+    factory: [ 'Drupal', 'config' ]
+    arguments: [ 'civiremote_funding.settings' ]
+
   civiremote_funding.civiremote.settings:
     class: Drupal\Core\Config\ImmutableConfig
     factory: ['Drupal', 'config']
@@ -175,3 +180,8 @@ services:
   Drupal\civiremote_funding\Controller\TransferContractDownloadController:
     class: Drupal\civiremote_funding\Controller\TransferContractDownloadController
     public: true
+
+  Drupal\civiremote_funding\JsonForms\Configurator\FileUploadArrayFactoryConfigurator:
+    class: Drupal\civiremote_funding\JsonForms\Configurator\FileUploadArrayFactoryConfigurator
+    arguments:
+      - '@civiremote_funding.settings'

--- a/config/install/civiremote_funding.settings.yml
+++ b/config/install/civiremote_funding.settings.yml
@@ -1,1 +1,2 @@
 file_cleanup_delay: 2592000 # 30 days
+file_upload_valid_extensions: 'jpg jpeg gif png txt doc docx xls xlsx pdf ppt pptx pps ppsx odt ods odp'

--- a/config/schema/civiremote_funding.schema.yml
+++ b/config/schema/civiremote_funding.schema.yml
@@ -4,3 +4,6 @@ civiremote_funding.settings:
     file_cleanup_delay:
       type: integer
       label: 'File clean up delay (seconds)'
+    file_upload_valid_extensions:
+      type: string
+      label: 'Valid file upload extensions separated by space (empty string to allow all extensions)'

--- a/config/schema/civiremote_funding.schema.yml
+++ b/config/schema/civiremote_funding.schema.yml
@@ -6,4 +6,4 @@ civiremote_funding.settings:
       label: 'File clean up delay (seconds)'
     file_upload_valid_extensions:
       type: string
-      label: 'Valid file upload extensions separated by space (empty string to allow all extensions)'
+      label: 'Allowed file extensions for uploaded files, separated by space. Leave empty to allow all file extensions.'

--- a/src/CiviremoteFundingServiceProvider.php
+++ b/src/CiviremoteFundingServiceProvider.php
@@ -20,9 +20,12 @@ declare(strict_types=1);
 
 namespace Drupal\civiremote_funding;
 
+use Drupal\civiremote_funding\JsonForms\Configurator\FileUploadArrayFactoryConfigurator;
+use Drupal\civiremote_funding\JsonForms\FileUploadArrayFactory;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\DependencyInjection\ServiceProviderInterface;
 use Drupal\json_forms\Form\Util\FactoryRegistrator;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @codeCoverageIgnore
@@ -35,6 +38,9 @@ final class CiviremoteFundingServiceProvider implements ServiceProviderInterface
       __DIR__ . '/JsonForms',
       'Drupal\\civiremote_funding\\JsonForms'
     );
+
+    $container->getDefinition(FileUploadArrayFactory::class)
+      ->setConfigurator(new Reference(FileUploadArrayFactoryConfigurator::class));
   }
 
 }

--- a/src/JsonForms/Configurator/FileUploadArrayFactoryConfigurator.php
+++ b/src/JsonForms/Configurator/FileUploadArrayFactoryConfigurator.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright (C) 2023 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Drupal\civiremote_funding\JsonForms\Configurator;
+
+use Drupal\civiremote_funding\JsonForms\FileUploadArrayFactory;
+use Drupal\Core\Config\ImmutableConfig;
+
+final class FileUploadArrayFactoryConfigurator {
+
+  private ImmutableConfig $config;
+
+  public function __construct(ImmutableConfig $config) {
+    $this->config = $config;
+  }
+
+  public function __invoke(FileUploadArrayFactory $fileUploadArrayFactory): void {
+    // @phpstan-ignore-next-line
+    $fileUploadArrayFactory->setValidFileExtensions($this->config->get('file_upload_valid_extensions'));
+  }
+
+}

--- a/src/JsonForms/FileUploadArrayFactory.php
+++ b/src/JsonForms/FileUploadArrayFactory.php
@@ -37,6 +37,8 @@ final class FileUploadArrayFactory extends AbstractConcreteFormArrayFactory {
 
   private FundingFileManager $fundingFileManager;
 
+  private ?string $validFileExtensions = NULL;
+
   public function __construct(FundingFileManager $fundingFileManager) {
     $this->fundingFileManager = $fundingFileManager;
   }
@@ -57,7 +59,13 @@ final class FileUploadArrayFactory extends AbstractConcreteFormArrayFactory {
     $form = [
       '#type' => 'managed_file',
       '#upload_location' => FundingFileInterface::UPLOAD_LOCATION,
+      '#upload_validators' => [],
     ] + BasicFormPropertiesFactory::createFieldProperties($definition, $formState);
+
+    if (NULL !== $this->validFileExtensions) {
+      // @phpstan-ignore-next-line
+      $form['#upload_validators']['file_validate_extensions'] = [$this->validFileExtensions];
+    }
 
     if (is_string($form['#default_value'] ?? NULL)) {
       $form['#default_value'] = $this->getValueForCiviUri($form['#default_value']);
@@ -80,6 +88,15 @@ final class FileUploadArrayFactory extends AbstractConcreteFormArrayFactory {
   public function supportsDefinition(DefinitionInterface $definition): bool {
     return $definition instanceof ControlDefinition && 'string' === $definition->getType()
       && 'uri' === $definition->getPropertyFormat() && 'file' === $definition->getControlFormat();
+  }
+
+  /**
+   * @param string|null $validFileExtensions
+   *   Space separated list of valid file extensions. Empty string to allow all
+   *   extensions. NULL to use Drupal's internal list of valid extensions.
+   */
+  public function setValidFileExtensions(?string $validFileExtensions): void {
+    $this->validFileExtensions = $validFileExtensions;
   }
 
   /**


### PR DESCRIPTION
Use custom valid file upload extensions instead of Drupal's internal list. For now the default stored in settings contains the extensions from Drupal 9 and OOXML extensions.

systopia-reference: 22886