### PR TITLE
Fixup int/bool drupal/php/civi mixup

### DIFF
--- a/config/optional/views.view.civiremote_funding_application_list.yml
+++ b/config/optional/views.view.civiremote_funding_application_list.yml
@@ -746,8 +746,8 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: cmrf_views_filter_boolean
-          operator: '!='
-          value: '1'
+          operator: '='
+          value: '0'
           group: 1
           exposed: false
           expose:


### PR DESCRIPTION
Error: Although there are two different views for combined and non-combined cases, only combined applications are displayed in both views (in conjunction with Civi Remote Funding) (CaseType flag is_combined_application set to 1). Apparently this is partly due to the operator in the non-combined view (!= 1 instead of = 0) and partly due to a faulty comparison with the Boolean.
At times we had the feeling that we had gone crazy.