### PR TITLE
Fix destination parameter in Views

### DIFF
--- a/config/optional/views.view.civiremote_funding_application_list.yml
+++ b/config/optional/views.view.civiremote_funding_application_list.yml
@@ -693,7 +693,7 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          path_format: raw-relative
+          path_format: alias-internal
           query_string_support: bypass-query-string
           query_params_filter: {  }
           query_params_filter_with_value: {  }

--- a/config/optional/views.view.civiremote_funding_combined_application_process_list.yml
+++ b/config/optional/views.view.civiremote_funding_combined_application_process_list.yml
@@ -690,7 +690,7 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          path_format: alias-relative
+          path_format: alias-internal
           query_string_support: bypass-query-string
           query_params_filter: {  }
           query_params_filter_with_value: {  }

--- a/config/optional/views.view.civiremote_funding_combined_case_list.yml
+++ b/config/optional/views.view.civiremote_funding_combined_case_list.yml
@@ -586,7 +586,7 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          path_format: raw-relative
+          path_format: alias-internal
           query_string_support: bypass-query-string
           query_params_filter: {  }
           query_params_filter_with_value: {  }

--- a/config/optional/views.view.civiremote_funding_transfer_contract_list.yml
+++ b/config/optional/views.view.civiremote_funding_transfer_contract_list.yml
@@ -651,7 +651,7 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          path_format: raw-relative
+          path_format: alias-internal
           query_string_support: bypass-query-string
           query_params_filter: {  }
           query_params_filter_with_value: {  }


### PR DESCRIPTION
Previously a path with two slashes at beginning was used in Views for the destination parameter if the URL path contained no language.