### PR TITLE
Filter by status in combined application list

### DIFF
--- a/civiremote_funding.module
+++ b/civiremote_funding.module
@@ -58,6 +58,23 @@ function civiremote_funding_views_pre_build(ViewExecutable $view): void {
 }
 
 /**
+ * Implements hook hook_form_FORM_ID_alter().
+ *
+ * @phpstan-param array<int|string, mixed> $form
+ */
+function civiremote_funding_form_views_exposed_form_alter(array &$form): void {
+  if ($form['#id'] === 'views-exposed-form-civiremote-funding-combined-application-process-list-embed-1') {
+    // Drupal uses the first URL of View display as URL for the filter form. So
+    // #action has the URL of the data export display, thus it has to be
+    // corrected. The approach to use a page in the View together with an
+    // area plugin leads to problems with the application process label (on the
+    // dropbutton) and the breadcrumbs.
+    $request = \Drupal::request();
+    $form['#action'] = $request->getSchemeAndHttpHost() . $request->getBaseUrl() . $request->getPathInfo();
+  }
+}
+
+/**
  * Implements hook_rebuild().
  */
 function civiremote_funding_rebuild(): void {

--- a/config/optional/views.view.civiremote_funding_combined_application_process_list.yml
+++ b/config/optional/views.view.civiremote_funding_combined_application_process_list.yml
@@ -967,7 +967,7 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: standard
-          order: ASC
+          order: DESC
           expose:
             label: ''
             field_identifier: ''
@@ -1038,7 +1038,46 @@ display:
             fail: 'not found'
           validate_options: {  }
           must_not_be: false
-      filters: {  }
+      filters:
+        status:
+          id: status
+          table: cmrf_views_civiremote_funding_application_process
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: cmrf_views_filter_optionlist
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: status_op
+            label: Status
+            description: ''
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list:
+              'not in': 'not in'
+            identifier: status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles: null
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       style:
         type: table
         options:


### PR DESCRIPTION
Adds the status field as exposed filter to the View `civiremote_funding_combined_application_process_list`.

systopia-reference: 25579