### PR TITLE
Do not use time to check if a new application in a funding program is possible

### DIFF
--- a/src/Controller/ChooseFundingProgramController.php
+++ b/src/Controller/ChooseFundingProgramController.php
@@ -112,9 +112,9 @@ final class ChooseFundingProgramController extends ControllerBase {
   }
 
   private function isInRequestPeriod(FundingProgram $fundingProgram): bool {
-    $now = new \DateTime(date('Y-m-d H:i:s'));
+    $today = new \DateTime(date('Y-m-d'));
 
-    return $now > $fundingProgram->getRequestsStartDate() && $now < $fundingProgram->getRequestsEndDate();
+    return $today >= $fundingProgram->getRequestsStartDate() && $today <= $fundingProgram->getRequestsEndDate();
   }
 
   private function isNewApplicationPossible(FundingProgram $fundingProgram): bool {


### PR DESCRIPTION
Requests start and end date of a funding program don't contain the time so the comparison has to be made without time.

systopia-reference: 28223