### PR TITLE
URL decode filenames when loading funding files from CiviCRM

### DIFF
--- a/src/File/FundingFileManager.php
+++ b/src/File/FundingFileManager.php
@@ -98,7 +98,7 @@ class FundingFileManager {
       return $fundingFile;
     }
 
-    $filename = basename($civiUri);
+    $filename = rawurldecode(basename($civiUri));
     Assertion::notEmpty($filename);
     $fileUri = FundingFileInterface::DOWNLOAD_LOCATION . $filename;
     $downloadDir = dirname($fileUri);


### PR DESCRIPTION
This avoids strings like `%20` in the filename shown to the user.

systopia-reference: 28324