### PR TITLE
Allow filenames in file upload element to wrap

### DIFF
--- a/civiremote_funding.libraries.yml
+++ b/civiremote_funding.libraries.yml
@@ -11,3 +11,8 @@ application_history:
     js/application/history.js: {}
   dependencies:
     - core/once
+
+file_field:
+  css:
+    theme:
+      css/file_field.css: {}

--- a/css/file_field.css
+++ b/css/file_field.css
@@ -1,0 +1,3 @@
+.civiremote-funding-file {
+  overflow-wrap: anywhere;
+}

--- a/src/JsonForms/FileUploadArrayFactory.php
+++ b/src/JsonForms/FileUploadArrayFactory.php
@@ -117,6 +117,12 @@ final class FileUploadArrayFactory extends AbstractConcreteFormArrayFactory {
         [static::class, 'processElement'],
       ],
       '#value_callback' => [static::class, 'valueCallback'],
+      '#attributes' => [
+        'class' => ['civiremote-funding-file'],
+      ],
+      '#attached' => [
+        'library' => ['civiremote_funding/file_field']
+      ]
     ] + BasicFormPropertiesFactory::createFieldProperties($definition, $formState);
 
     if (NULL !== $this->validFileExtensions) {


### PR DESCRIPTION
This prevents long filenames from hiding other content/occupying to much space in a table.

systopia-reference: 28324