### PR TITLE
Cache form state to improve performance

### DIFF
--- a/src/Form/AbstractFundingJsonFormsForm.php
+++ b/src/Form/AbstractFundingJsonFormsForm.php
@@ -72,6 +72,12 @@ abstract class AbstractFundingJsonFormsForm extends AbstractJsonFormsForm {
       $form_state->set('jsonSchema', $fundingForm->getJsonSchema());
       $form_state->set('uiSchema', $fundingForm->getUiSchema());
       $form_state->setTemporary($fundingForm->getData());
+
+      if (!$this->getRequest()->isMethodSafe()) {
+        // Cache form state so the form specification hasn't to be rebuilt on
+        // every AJAX request. (Drupal prevents caching on safe methods.)
+        $form_state->setCached();
+      }
     }
 
     $form = $this->buildJsonFormsForm(


### PR DESCRIPTION
The form state is now cached on the first AJAX request. This prevents that the form specification has to be rebuilt for every AJAX request and thus improves performance.

systopia-reference: 28967