### PR TITLE
Cache form after build

### DIFF
--- a/src/Form/AbstractFundingJsonFormsForm.php
+++ b/src/Form/AbstractFundingJsonFormsForm.php
@@ -72,12 +72,6 @@ abstract class AbstractFundingJsonFormsForm extends AbstractJsonFormsForm {
       $form_state->set('jsonSchema', $fundingForm->getJsonSchema());
       $form_state->set('uiSchema', $fundingForm->getUiSchema());
       $form_state->setTemporary($fundingForm->getData());
-
-      if (!$this->getRequest()->isMethodSafe()) {
-        // Cache form state so the form specification hasn't to be rebuilt on
-        // every AJAX request. (Drupal prevents caching on safe methods.)
-        $form_state->setCached();
-      }
     }
 
     $form = $this->buildJsonFormsForm(
@@ -92,6 +86,12 @@ abstract class AbstractFundingJsonFormsForm extends AbstractJsonFormsForm {
 
     // @phpstan-ignore-next-line
     $form['#attributes']['class'][] = 'civiremote-funding-form';
+
+    if (!$form_state->isCached() && !$this->getRequest()->isMethodSafe()) {
+      // Cache form state so the form specification hasn't to be rebuilt on
+      // every AJAX request. (Drupal prevents caching on safe methods.)
+      $form_state->setCached();
+    }
 
     return $form;
   }


### PR DESCRIPTION
Actually it is always cached after build. But this change ensures that the correct value is returned when it is checked during form build if the form was cached.