### PR TITLE
Add application history element for the `funding_application_move` activity

### DIFF
--- a/src/Api/DTO/ApplicationProcessActivity.php
+++ b/src/Api/DTO/ApplicationProcessActivity.php
@@ -76,14 +76,14 @@ final class ApplicationProcessActivity extends AbstractDTO {
   }
 
   /**
-   * @return string Empty if not set, e.g. no comment.
+   * @return string Empty if not set, i.e. no comment.
    */
   public function getAction(): string {
     return $this->values['action'] ?? '';
   }
 
   /**
-   * @return string Empty if not set, e.g. no status change.
+   * @return string Empty if not set, i.e. no status change.
    */
   public function getFromStatus(): string {
     return $this->values['from_status'] ?? '';
@@ -94,6 +94,24 @@ final class ApplicationProcessActivity extends AbstractDTO {
    */
   public function getToStatus(): string {
     return $this->values['to_status'] ?? '';
+  }
+
+  /**
+   * @return string Empty if not set, i.e. no move activity.
+   */
+  public function getFromFundingCaseIdentifier(): string {
+    return $this->values['from_funding_case_identifier'] ?? '';
+  }
+
+  /**
+   * @return string Empty if not set, i.e. no move activity.
+   */
+  public function getToFundingCaseIdentifier(): string {
+    return $this->values['to_funding_case_identifier'] ?? '';
+  }
+
+  public function getPreviousApplicationProcessIdentifier(): string {
+    return $this->values['previous_application_process_identifier'] ?? '';
   }
 
 }

--- a/src/Element/CiviremoteFundingApplicationHistory.php
+++ b/src/Element/CiviremoteFundingApplicationHistory.php
@@ -22,13 +22,12 @@ namespace Drupal\civiremote_funding\Element;
 
 use Drupal\civiremote_funding\Api\DTO\ApplicationProcessActivity;
 use Drupal\civiremote_funding\Api\DTO\Option;
-use Drupal\Core\Render\Element\RenderElement;
+use Drupal\Core\Render\Attribute\RenderElement;
+use Drupal\Core\Render\Element\RenderElementBase;
 use Drupal\Core\Url;
 
-/**
- * @RenderElement("civiremote_funding_application_history")
- */
-final class CiviremoteFundingApplicationHistory extends RenderElement {
+#[RenderElement('civiremote_funding_application_history')]
+final class CiviremoteFundingApplicationHistory extends RenderElementBase {
 
   /**
    * {@inheritDoc}
@@ -162,6 +161,13 @@ final class CiviremoteFundingApplicationHistory extends RenderElement {
           '#activity' => $activity,
           '#icon' => $withIcon ? $statusOption->getIcon() : NULL,
           '#icon_color' => $statusOption->getColor(),
+        ];
+
+      case 'funding_application_move':
+        return [
+          '#type' => 'civiremote_funding_application_history_move',
+          '#activity' => $activity,
+          '#icon' => $withIcon ? 'fa-arrow-circle-right' : NULL,
         ];
 
       case 'funding_clearing_status_change':

--- a/src/Element/CiviremoteFundingApplicationHistoryMove.php
+++ b/src/Element/CiviremoteFundingApplicationHistoryMove.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Drupal\civiremote_funding\Element;
+
+use Assert\Assertion;
+use Drupal\civiremote_funding\Api\DTO\ApplicationProcessActivity;
+use Drupal\Core\Render\Attribute\RenderElement;
+use Drupal\Core\Render\Element\RenderElementBase;
+
+#[RenderElement('civiremote_funding_application_history_move')]
+final class CiviremoteFundingApplicationHistoryMove extends RenderElementBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getInfo(): array {
+    return [
+      // Instance of ApplicationProcessActivity.
+      '#activity' => NULL,
+      '#title' => $this->t('Moved to funding case @identifier'),
+      '#status_label' => NULL,
+      '#source_contact_title' => $this->t('Performed by'),
+      '#previous_funding_case_title' => $this->t('Previous funding case'),
+      '#previous_application_identifier_title' => $this->t('Previous application identifier'),
+      '#pre_render' => [
+        [__CLASS__, 'preRenderActivity'],
+      ],
+    ];
+  }
+
+  /**
+   * @phpstan-param array<string, mixed> $element
+   *
+   * @phpstan-return array<string, mixed>
+   */
+  public static function preRenderActivity(array $element): array {
+    /** @var \Drupal\Core\Datetime\DateFormatterInterface $dateFormatter */
+    $dateFormatter = \Drupal::service('date.formatter');
+
+    if (is_scalar($element['#title']) ||
+      (is_object($element['#title']) && method_exists($element['#title'], '__toString'))
+    ) {
+      $element['#title'] = (string) $element['#title'];
+    }
+    else {
+      throw new \InvalidArgumentException('Expected string for "#title", got ' . gettype($element['#title']));
+    }
+
+    Assertion::isInstanceOf($element['#activity'], ApplicationProcessActivity::class);
+    /** @var \Drupal\civiremote_funding\Api\DTO\ApplicationProcessActivity $activity */
+    $activity = $element['#activity'];
+
+    $element['activity'] = [
+      '#type' => 'civiremote_funding_application_history_entry',
+      '#attributes' => ['data-activity-kind' => 'workflow'],
+      '#icon' => $element['#icon'],
+      '#icon_color' => $element['#icon_color'],
+      '#title' => \Drupal::translation()->translate($element['#title'], [
+        '@identifier' => $activity->getToFundingCaseIdentifier(),
+      ]),
+      '#date' => $dateFormatter->format($activity->getCreatedDate()->getTimestamp()),
+      '#content' => [
+        '#type' => 'container',
+        'source_contact' => [
+          '#type' => 'item',
+          '#title' => $element['#source_contact_title'],
+          '#markup' => htmlentities($activity->getSourceContactName()),
+        ],
+        'previous_funding_case' => [
+          '#type' => 'item',
+          '#title' => $element['#previous_funding_case_title'],
+          '#markup' => $activity->getFromFundingCaseIdentifier(),
+        ],
+        'previous_application_identifier' => [
+          '#type' => 'item',
+          '#title' => $element['#previous_application_identifier_title'],
+          '#markup' => $activity->getPreviousApplicationProcessIdentifier(),
+        ],
+      ],
+    ];
+
+    return $element;
+  }
+
+}

--- a/translations/civiremote_funding.pot
+++ b/translations/civiremote_funding.pot
@@ -412,7 +412,7 @@ msgstr ""
 msgid "Please do not forget to apply the combined application if everything is recorded or after additions."
 msgstr ""
 
-#: src/Controller/FundingCaseController.php:82
+#: src/Controller/FundingCaseController.php:83
 msgid "Add @type"
 msgstr ""
 
@@ -420,23 +420,23 @@ msgstr ""
 msgid "Transfer Contract: @identifier"
 msgstr ""
 
-#: src/Element/CiviremoteFundingApplicationHistory.php:44
+#: src/Element/CiviremoteFundingApplicationHistory.php:43
 msgid "Unknown"
 msgstr ""
 
-#: src/Element/CiviremoteFundingApplicationHistory.php:50
+#: src/Element/CiviremoteFundingApplicationHistory.php:49
 msgid "Back"
 msgstr ""
 
-#: src/Element/CiviremoteFundingApplicationHistory.php:51
+#: src/Element/CiviremoteFundingApplicationHistory.php:50
 msgid "Filter"
 msgstr ""
 
-#: src/Element/CiviremoteFundingApplicationHistory.php:52
+#: src/Element/CiviremoteFundingApplicationHistory.php:51
 msgid "Hide workflow actions"
 msgstr ""
 
-#: src/Element/CiviremoteFundingApplicationHistory.php:53
+#: src/Element/CiviremoteFundingApplicationHistory.php:52
 msgid "Hide comments"
 msgstr ""
 
@@ -446,6 +446,7 @@ msgstr ""
 
 #: src/Element/CiviremoteFundingApplicationHistoryComment.php:42
 #: src/Element/CiviremoteFundingApplicationHistoryCreate.php:40
+#: src/Element/CiviremoteFundingApplicationHistoryMove.php:40
 #: src/Element/CiviremoteFundingApplicationHistoryStatusChange.php:44
 #: src/Element/CiviremoteFundingClearingHistoryCreate.php:40
 #: src/Element/CiviremoteFundingClearingHistoryStatusChange.php:44
@@ -455,6 +456,18 @@ msgstr ""
 #: src/Element/CiviremoteFundingApplicationHistoryCreate.php:39
 #: src/Entity/FundingFile.php:86
 msgid "Created"
+msgstr ""
+
+#: src/Element/CiviremoteFundingApplicationHistoryMove.php:38
+msgid "Moved to funding case @identifier"
+msgstr ""
+
+#: src/Element/CiviremoteFundingApplicationHistoryMove.php:41
+msgid "Previous funding case"
+msgstr ""
+
+#: src/Element/CiviremoteFundingApplicationHistoryMove.php:42
+msgid "Previous application identifier"
 msgstr ""
 
 #: src/Element/CiviremoteFundingApplicationHistoryStatusChange.php:42

--- a/translations/de.po
+++ b/translations/de.po
@@ -438,7 +438,7 @@ msgstr ""
 "Bitte nicht vergessen, den Sammelantrag zu beantragen, wenn alles erfasst wurde oder nach "
 "Ergänzungen."
 
-#: src/Controller/FundingCaseController.php:82
+#: src/Controller/FundingCaseController.php:83
 msgid "Add @type"
 msgstr "@type hinzufügen"
 
@@ -446,23 +446,23 @@ msgstr "@type hinzufügen"
 msgid "Transfer Contract: @identifier"
 msgstr "Weiterleitungsvertrag: @identifier"
 
-#: src/Element/CiviremoteFundingApplicationHistory.php:44
+#: src/Element/CiviremoteFundingApplicationHistory.php:43
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: src/Element/CiviremoteFundingApplicationHistory.php:50
+#: src/Element/CiviremoteFundingApplicationHistory.php:49
 msgid "Back"
 msgstr "Zurück"
 
-#: src/Element/CiviremoteFundingApplicationHistory.php:51
+#: src/Element/CiviremoteFundingApplicationHistory.php:50
 msgid "Filter"
 msgstr "Filter"
 
-#: src/Element/CiviremoteFundingApplicationHistory.php:52
+#: src/Element/CiviremoteFundingApplicationHistory.php:51
 msgid "Hide workflow actions"
 msgstr "Ablaufaktivitäten ausblenden"
 
-#: src/Element/CiviremoteFundingApplicationHistory.php:53
+#: src/Element/CiviremoteFundingApplicationHistory.php:52
 msgid "Hide comments"
 msgstr "Kommentare ausblenden"
 
@@ -472,6 +472,7 @@ msgstr "Kommentar"
 
 #: src/Element/CiviremoteFundingApplicationHistoryComment.php:42
 #: src/Element/CiviremoteFundingApplicationHistoryCreate.php:40
+#: src/Element/CiviremoteFundingApplicationHistoryMove.php:40
 #: src/Element/CiviremoteFundingApplicationHistoryStatusChange.php:44
 #: src/Element/CiviremoteFundingClearingHistoryCreate.php:40
 #: src/Element/CiviremoteFundingClearingHistoryStatusChange.php:44
@@ -482,6 +483,18 @@ msgstr "Durchgeführt von"
 #: src/Entity/FundingFile.php:86
 msgid "Created"
 msgstr "Erstellt"
+
+#: src/Element/CiviremoteFundingApplicationHistoryMove.php:38
+msgid "Moved to funding case @identifier"
+msgstr "In Förderfall @identifier verschoben"
+
+#: src/Element/CiviremoteFundingApplicationHistoryMove.php:41
+msgid "Previous funding case"
+msgstr "Vorheriger Förderfall"
+
+#: src/Element/CiviremoteFundingApplicationHistoryMove.php:42
+msgid "Previous application identifier"
+msgstr "Vorherige Antragsnummer"
 
 #: src/Element/CiviremoteFundingApplicationHistoryStatusChange.php:42
 msgid "Status: @status"


### PR DESCRIPTION
This makes a `funding_application_move` activity render like this:
<img width="704" height="198" alt="screenshot" src="https://github.com/user-attachments/assets/e3e89ded-1135-44eb-8b3b-991b75bbb773" />

Corresponds to https://github.com/systopia/funding/pull/620

systopia-reference: 34334